### PR TITLE
Combined arms slots

### DIFF
--- a/game/event/event.py
+++ b/game/event/event.py
@@ -21,6 +21,7 @@ class Event:
     silent = False
     informational = False
     is_awacs_enabled = False
+    ca_slots = 0
     operation = None  # type: Operation
     difficulty = 1  # type: int
     game = None  # type: Game
@@ -74,6 +75,7 @@ class Event:
 
     def generate(self):
         self.operation.is_awacs_enabled = self.is_awacs_enabled
+        self.operation.ca_slots = self.ca_slots
 
         self.operation.prepare(self.game.theater.terrain, is_quick=False)
         self.operation.generate()

--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -92,8 +92,10 @@ class Operation:
 
         # combined arms
         self.mission.groundControl.pilot_can_control_vehicles = self.ca_slots > 0
-        self.mission.groundControl.blue_tactical_commander = self.ca_slots
-        self.mission.groundControl.red_tactical_commander = self.ca_slots
+        if self.game.player == "USA":
+            self.mission.groundControl.blue_tactical_commander = self.ca_slots
+        else:
+            self.mission.groundControl.red_tactical_commander = self.ca_slots
 
         # ground infrastructure
         self.groundobjectgen.generate()

--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -27,6 +27,7 @@ class Operation:
     trigger_radius = TRIGGER_RADIUS_MEDIUM
     is_quick = None
     is_awacs_enabled = False
+    ca_slots = 0
 
     def __init__(self,
                  game,
@@ -50,7 +51,6 @@ class Operation:
     def initialize(self, mission: Mission, conflict: Conflict):
         self.mission = mission
         self.conflict = conflict
-
         self.armorgen = ArmorConflictGenerator(mission, conflict)
         self.airgen = AircraftConflictGenerator(mission, conflict, self.game.settings)
         self.aagen = AAConflictGenerator(mission, conflict)
@@ -89,6 +89,11 @@ class Operation:
         self.briefinggen.append_frequency("Tanker", "10X/131 MHz AM")
         if self.is_awacs_enabled:
             self.briefinggen.append_frequency("AWACS", "133 MHz AM")
+
+        # combined arms
+        self.mission.groundControl.pilot_can_control_vehicles = self.ca_slots > 0
+        self.mission.groundControl.blue_tactical_commander = self.ca_slots
+        self.mission.groundControl.red_tactical_commander = self.ca_slots
 
         # ground infrastructure
         self.groundobjectgen.generate()

--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -92,7 +92,7 @@ class Operation:
 
         # combined arms
         self.mission.groundControl.pilot_can_control_vehicles = self.ca_slots > 0
-        if self.game.player == "USA":
+        if self.game.player in [country.name for country in self.mission.coalition["blue"].countries.values()]:
             self.mission.groundControl.blue_tactical_commander = self.ca_slots
         else:
             self.mission.groundControl.red_tactical_commander = self.ca_slots

--- a/gen/armor.py
+++ b/gen/armor.py
@@ -45,6 +45,9 @@ class ArmorConflictGenerator:
                     group_size=1,
                     move_formation=PointAction.OffRoad)
 
+            vehicle: Vehicle = group.units[0]
+            vehicle.player_can_drive = True
+
             if not to:
                 to = self.conflict.position.point_from_heading(0, 500)
 

--- a/ui/eventmenu.py
+++ b/ui/eventmenu.py
@@ -9,7 +9,7 @@ from .styles import STYLES, RED
 
 class EventMenu(Menu):
     scramble_entries = None  # type: typing.Dict[typing.Type[Task], typing.Dict[typing.Type[UnitType], typing.Tuple[Entry, Entry]]]
-
+    ca_slot_entry = None
     error_label = None  # type: Label
     awacs = None  # type: IntVar
 
@@ -100,8 +100,15 @@ class EventMenu(Menu):
         header("Support:")
         # Options
         awacs_enabled = self.game.budget >= AWACS_BUDGET_COST and NORMAL or DISABLED
-        Checkbutton(self.frame, var=self.awacs, state=awacs_enabled,  **STYLES["radiobutton"]).grid(row=row, column=0, sticky=E)
-        Label(self.frame, text="AWACS ({}m)".format(AWACS_BUDGET_COST), **STYLES["widget"]).grid(row=row, column=3, sticky=W, padx=5, pady=5)
+        Label(self.frame, text="AWACS ({}m)".format(AWACS_BUDGET_COST), **STYLES["widget"]).grid(row=row, column=0, sticky=W)
+        Checkbutton(self.frame, var=self.awacs, state=awacs_enabled,  **STYLES["radiobutton"]).grid(row=row, column=3, sticky=E)
+        row += 1
+
+        Label(self.frame, text="Combined Arms Slots", **STYLES["widget"]).grid(row=row, sticky=W)
+        self.ca_slot_entry = Entry(self.frame,  width=2)
+        self.ca_slot_entry.insert(0, "0")
+        self.ca_slot_entry.grid(column=2, row=row, sticky=E, padx=5)
+        Button(self.frame, text="+", command=self.add_ca_slot, **STYLES["btn-primary"]).grid(column=3, row=row, padx=15)
         row += 1
 
         header("Ready?")
@@ -124,6 +131,12 @@ class EventMenu(Menu):
 
         return action
 
+    def add_ca_slot(self):
+        value = self.ca_slot_entry.get()
+        amount = int(value and value or "0")
+        self.ca_slot_entry.delete(0, END)
+        self.ca_slot_entry.insert(0, str(amount+1))
+
     def client_one(self, task: typing.Type[Task], unit_type: UnitType) -> typing.Callable:
         def action():
             entry = self.scramble_entries[task][unit_type][1]  # type: Entry
@@ -139,6 +152,10 @@ class EventMenu(Menu):
             self.game.awacs_expense_commit()
         else:
             self.event.is_awacs_enabled = False
+
+        ca_slot_entry_value = self.ca_slot_entry.get()
+        ca_slots = int(ca_slot_entry_value and ca_slot_entry_value or "0")
+        self.event.ca_slots = ca_slots
 
         flights = {k: {} for k in self.event.tasks}  # type: db.TaskForceDict
         units_scramble_counts = {}  # type: typing.Dict[typing.Type[UnitType], int]

--- a/ui/eventmenu.py
+++ b/ui/eventmenu.py
@@ -154,7 +154,10 @@ class EventMenu(Menu):
             self.event.is_awacs_enabled = False
 
         ca_slot_entry_value = self.ca_slot_entry.get()
-        ca_slots = int(ca_slot_entry_value and ca_slot_entry_value or "0")
+        try:
+            ca_slots = int(ca_slot_entry_value and ca_slot_entry_value or "0")
+        except:
+            ca_slots = 0
         self.event.ca_slots = ca_slots
 
         flights = {k: {} for k in self.event.tasks}  # type: db.TaskForceDict

--- a/ui/eventmenu.py
+++ b/ui/eventmenu.py
@@ -9,7 +9,7 @@ from .styles import STYLES, RED
 
 class EventMenu(Menu):
     scramble_entries = None  # type: typing.Dict[typing.Type[Task], typing.Dict[typing.Type[UnitType], typing.Tuple[Entry, Entry]]]
-    ca_slot_entry = None
+    ca_slot_entry = None  # type: Entry
     error_label = None  # type: Label
     awacs = None  # type: IntVar
 

--- a/ui/eventmenu.py
+++ b/ui/eventmenu.py
@@ -100,15 +100,15 @@ class EventMenu(Menu):
         header("Support:")
         # Options
         awacs_enabled = self.game.budget >= AWACS_BUDGET_COST and NORMAL or DISABLED
-        Label(self.frame, text="AWACS ({}m)".format(AWACS_BUDGET_COST), **STYLES["widget"]).grid(row=row, column=0, sticky=W)
-        Checkbutton(self.frame, var=self.awacs, state=awacs_enabled,  **STYLES["radiobutton"]).grid(row=row, column=3, sticky=E)
+        Checkbutton(self.frame, var=self.awacs, state=awacs_enabled,  **STYLES["radiobutton"]).grid(row=row, column=2, sticky=E)
+        Label(self.frame, text="AWACS ({}m)".format(AWACS_BUDGET_COST), **STYLES["widget"]).grid(row=row, column=0, sticky=W, pady=5)
         row += 1
 
         Label(self.frame, text="Combined Arms Slots", **STYLES["widget"]).grid(row=row, sticky=W)
         self.ca_slot_entry = Entry(self.frame,  width=2)
         self.ca_slot_entry.insert(0, "0")
-        self.ca_slot_entry.grid(column=2, row=row, sticky=E, padx=5)
-        Button(self.frame, text="+", command=self.add_ca_slot, **STYLES["btn-primary"]).grid(column=3, row=row, padx=15)
+        self.ca_slot_entry.grid(column=1, row=row, sticky=W, padx=5)
+        Button(self.frame, text="+", command=self.add_ca_slot, **STYLES["btn-primary"]).grid(column=2, row=row, padx=5, sticky=W)
         row += 1
 
         header("Ready?")


### PR DESCRIPTION
This add a new UI element to select whether to add Combined Arms slots to the generated mission. 

![image](https://user-images.githubusercontent.com/2546901/45916908-b4460300-be6d-11e8-8c2f-1175679a7def.png)

* The slots added to the mission are "Tactical Commander" slots.
* The option to allow players 'in flight' to give orders to units is also enabled, when combined arms slots are added. (See dcs.Mission.groundControl.player_can_control_vehicles from pydcs)
* CA slots are only added to player side