### PR TITLE
Labels and coalition view

### DIFF
--- a/game/operation/operation.py
+++ b/game/operation/operation.py
@@ -26,6 +26,7 @@ class Operation:
     envgen = None  # type: EnvironmentGenerator
     groundobjectgen = None  # type: GroundObjectsGenerator
     briefinggen = None  # type: BriefingGenerator
+    forcedoptionsgen = None  # type: ForcedOptionsGenerator
 
     environment_settings = None
     trigger_radius = TRIGGER_RADIUS_MEDIUM
@@ -63,6 +64,7 @@ class Operation:
         self.triggersgen = TriggersGenerator(mission, conflict, self.game)
         self.visualgen = VisualGenerator(mission, conflict, self.game)
         self.envgen = EnviromentGenerator(mission, conflict, self.game)
+        self.forcedoptionsgen = ForcedOptionsGenerator(mission, conflict, self.game)
         self.groundobjectgen = GroundObjectsGenerator(mission, conflict, self.game)
         self.briefinggen = BriefingGenerator(mission, conflict, self.game)
 
@@ -140,6 +142,8 @@ class Operation:
             self.environment_settings = self.envgen.generate()
         else:
             self.envgen.load(self.environment_settings)
+
+        self.forcedoptionsgen.generate()
 
         # main frequencies
         self.briefinggen.append_frequency("Flight", "251 MHz AM")

--- a/game/settings.py
+++ b/game/settings.py
@@ -3,6 +3,8 @@ class Settings:
     player_skill = "Good"
     enemy_skill = "Average"
     enemy_vehicle_skill = "Average"
+    map_coalition_visibility = "All Units"
+    labels = "Full"
     only_player_takeoff = True
     night_disabled = False
 

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -9,6 +9,7 @@ from .triggergen import *
 from .environmentgen import *
 from .groundobjectsgen import *
 from .briefinggen import *
+from .forcedoptionsgen import *
 
 from . import naming
 

--- a/gen/forcedoptionsgen.py
+++ b/gen/forcedoptionsgen.py
@@ -1,0 +1,45 @@
+import logging
+import typing
+from enum import IntEnum
+
+from dcs.mission import Mission
+from dcs.forcedoptions import ForcedOptions
+
+from .conflictgen import *
+
+
+class Labels(IntEnum):
+    Off = 0
+    Full = 1
+    Abbreviated = 2
+    Dot = 3
+
+
+class ForcedOptionsGenerator:
+    def __init__(self, mission: Mission, conflict: Conflict, game):
+        self.mission = mission
+        self.conflict = conflict
+        self.game = game
+
+    def _set_options_view(self):
+        if self.game.settings.map_coalition_visibility == "All Units":
+            self.mission.forced_options.options_view = ForcedOptions.Views.All
+        elif self.game.settings.map_coalition_visibility == "Allied Units":
+            self.mission.forced_options.options_view = ForcedOptions.Views.Allies
+        elif self.game.settings.map_coalition_visibility == "Own Aircraft":
+            self.mission.forced_options.options_view = ForcedOptions.Views.MyAircraft
+        elif self.game.settings.map_coalition_visibility == "None":
+            self.mission.forced_options.options_view = ForcedOptions.Views.OnlyMap
+
+    def _set_labels(self):
+        if self.game.settings.labels == "Abbreviated":
+            self.mission.forced_options.labels = int(Labels.Abbreviated)
+        elif self.game.settings.labels == "Dot Only":
+            self.mission.forced_options.labels = int(Labels.Dot)
+        elif self.game.settings.labels == "Off":
+            self.mission.forced_options.labels = int(Labels.Off)
+
+    def generate(self):
+        self._set_options_view()
+        self._set_labels()
+        

--- a/ui/configurationmenu.py
+++ b/ui/configurationmenu.py
@@ -104,9 +104,6 @@ class ConfigurationMenu(Menu):
         Checkbutton(body, variable=self.night_var, **STYLES["radiobutton"]).grid(row=row, column=1, sticky=E)
         row += 1
 
-        Button(body, text="Display logs", command=self.display_logs, **STYLES["btn-primary"]).grid(row=row, column=1, sticky=E, pady=30)
-        row += 1
-
         Label(body, text="Contributors: ", **STYLES["strong"]).grid(row=row, column=0, columnspan=2, sticky=EW)
         row += 1
 
@@ -118,7 +115,8 @@ class ConfigurationMenu(Menu):
         Button(body, text="[github]", command=lambda: webbrowser.open_new_tab("http://github.com/Khopa"), **STYLES["widget"]).grid(row=row, column=1, sticky=E)
         row += 1
 
-        Button(body, text="Cheat +200m", command=self.cheat_money, **STYLES["btn-danger"]).grid(row=row, column=1, pady=30)
+        Button(body, text="Display logs", command=self.display_logs, **STYLES["btn-primary"]).grid(row=row, column=0, pady=5)
+        Button(body, text="Cheat +200m", command=self.cheat_money, **STYLES["btn-danger"]).grid(row=row, column=1)
 
     def display_logs(self):
         raise ShowLogsException()

--- a/ui/configurationmenu.py
+++ b/ui/configurationmenu.py
@@ -21,6 +21,12 @@ class ConfigurationMenu(Menu):
         self.enemy_vehicle_var = StringVar()
         self.enemy_vehicle_var.set(self.game.settings.enemy_vehicle_skill)
 
+        self.map_coalition_visibility_var = StringVar()
+        self.map_coalition_visibility_var.set(self.game.settings.map_coalition_visibility)
+
+        self.labels_var = StringVar()
+        self.labels_var.set(self.game.settings.labels)
+
         self.takeoff_var = BooleanVar()
         self.takeoff_var.set(self.game.settings.only_player_takeoff)
 
@@ -34,6 +40,8 @@ class ConfigurationMenu(Menu):
         self.game.settings.player_skill = self.player_skill_var.get()
         self.game.settings.enemy_skill = self.enemy_skill_var.get()
         self.game.settings.enemy_vehicle_skill = self.enemy_vehicle_var.get()
+        self.game.settings.map_coalition_visibility = self.map_coalition_visibility_var.get()
+        self.game.settings.labels = self.labels_var.get()
         self.game.settings.only_player_takeoff = self.takeoff_var.get()
         self.game.settings.night_disabled = self.night_var.get()
         self.game.settings.cold_start = self.cold_start_var.get()
@@ -70,6 +78,18 @@ class ConfigurationMenu(Menu):
         e_skill = OptionMenu(body, self.enemy_vehicle_var, "Average", "Good", "High", "Excellent")
         e_skill.grid(row=row, column=1, sticky=E)
         e_skill.configure(**STYLES["btn-primary"])
+        row += 1
+
+        Label(body, text="F10 Map Coalition Visibility", **STYLES["widget"]).grid(row=row, column=0, sticky=W)
+        map_vis = OptionMenu(body, self.map_coalition_visibility_var, "All Units", "Allied Units", "Own Aircraft", "None")
+        map_vis.grid(row=row, column=1, sticky=E)
+        map_vis.configure(**STYLES["btn-primary"])
+        row += 1
+
+        Label(body, text="In Game Labels", **STYLES["widget"]).grid(row=row, column=0, sticky=W)
+        g_labels = OptionMenu(body, self.labels_var, "Full", "Abbreviated", "Dot Only", "Off")
+        g_labels.grid(row=row, column=1, sticky=E)
+        g_labels.configure(**STYLES["btn-primary"])
         row += 1
 
         Label(body, text="Aircraft cold start", **STYLES["widget"]).grid(row=row, column=0, sticky=W)


### PR DESCRIPTION
This PR adds two new configuration menu options for Map (and unit) visibility restrictions as well as the option to restrict labels.

Currently neither of these options are set resulting in DCS defaulting to allowing players to see all units (friendly and enemy) on the map as well as defaulting to Full Labels.

Both of these options can be restricted at mission generation time for players who want more realism and/or more difficulty.