### PR TITLE
ValueError: negative radius

### DIFF
--- a/ui/overviewcanvas.py
+++ b/ui/overviewcanvas.py
@@ -320,7 +320,7 @@ class OverviewCanvas:
         for cp in self.game.theater.controlpoints:
             coords = self._transform_point(cp.position)
             radius = 12 * math.pow(cp.importance, 1)
-            radius_m = radius * cp.base.strength - 2
+            radius_m = max(radius * cp.base.strength - 2, 0)
 
             if cp.captured:
                 color = self._player_color()


### PR DESCRIPTION
When cp.base.strength is zero 0, radius_m becomes negative and an ValueError is raised.

INFO:root:Commision Al Maktoum: {<class 'dcs.vehicles.Armor.APC_BTR_80'>: 3}
ERROR:root:<class 'ValueError'>
Traceback (most recent call last):
  File "tkinter\__init__.py", line 1702, in __call__
  File "ui\window.py", line 156, in dismiss
  File "ui\mainmenu.py", line 29, in display
  File "ui\overviewcanvas.py", line 590, in update
  File "ui\overviewcanvas.py", line 252, in draw
  File "ui\overviewcanvas.py", line 312, in draw_map
  File "ui\overviewcanvas.py", line 331, in draw_bases
ValueError: negative radius

Proposed fix:
radius_m = max(radius * cp.base.strength - 2, 0)